### PR TITLE
Fix "function already exists" error on reload

### DIFF
--- a/plugin/konsole.vim
+++ b/plugin/konsole.vim
@@ -8,14 +8,14 @@ augroup KDE
     autocmd BufReadPost * :silent :call <sid>update_session_name()
     autocmd VimLeavePre * :silent :call <sid>clear_session_name()
 augroup END
-function s:update_session_name()
+function! s:update_session_name()
     if !empty(@%)
         !qdbus org.kde.konsole $KONSOLE_DBUS_SESSION org.kde.konsole.Session.setTitle 1 %
     else
         !qdbus org.kde.konsole $KONSOLE_DBUS_SESSION org.kde.konsole.Session.setTitle 1 'empty'
     endif
 endfunction
-function s:clear_session_name()
+function! s:clear_session_name()
     !qdbus org.kde.konsole $KONSOLE_DBUS_SESSION org.kde.konsole.Session.setTitle 1 $PWD
 endfunction
 


### PR DESCRIPTION
Fix for "Function <FUNCTION_NAME> already exists, add ! to replace it"
when reloading the plugin (eg. following an update via the vundle plugin
manager).
