### PR TITLE
Fix for error on filenames with special chars

### DIFF
--- a/plugin/konsole.vim
+++ b/plugin/konsole.vim
@@ -10,13 +10,14 @@ augroup KDE
 augroup END
 function! s:update_session_name()
     if !empty(@%)
-        !qdbus org.kde.konsole $KONSOLE_DBUS_SESSION org.kde.konsole.Session.setTitle 1 %
+		" Cf. http://stackoverflow.com/questions/5608112/escape-filenames-using-the-same-way-bash-do-it
+        !qdbus org.kde.konsole $KONSOLE_DBUS_SESSION org.kde.konsole.Session.setTitle 1 $(printf '%q' %)
     else
         !qdbus org.kde.konsole $KONSOLE_DBUS_SESSION org.kde.konsole.Session.setTitle 1 'empty'
     endif
 endfunction
 function! s:clear_session_name()
-    !qdbus org.kde.konsole $KONSOLE_DBUS_SESSION org.kde.konsole.Session.setTitle 1 $PWD
+    !qdbus org.kde.konsole $KONSOLE_DBUS_SESSION org.kde.konsole.Session.setTitle 1 $(printf '%q' "$PWD")
 endfunction
 
 

--- a/plugin/konsole.vim
+++ b/plugin/konsole.vim
@@ -17,7 +17,7 @@ function! s:update_session_name()
     endif
 endfunction
 function! s:clear_session_name()
-    !qdbus org.kde.konsole $KONSOLE_DBUS_SESSION org.kde.konsole.Session.setTitle 1 $(printf '%q' "$PWD")
+    !qdbus org.kde.konsole $KONSOLE_DBUS_SESSION org.kde.konsole.Session.setTitle 1 $PWD
 endfunction
 
 


### PR DESCRIPTION
Opening a file with an apostrophe (Captain's.log in this case) throws a (non-blocking) error on stderr:
/bin/bash: -c: line 0: unexpected EOF while looking for matching `''
(That message ends with: backtick, single-quote, single-quote.)

The fix (escaping the filename) comes from
  http://stackoverflow.com/questions/5608112/escape-filenames-using-the-same-way-bash-do-it
